### PR TITLE
raw.github.com -> github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 JSON-LD Macros is a library to define declarative transformations of JSON objects obtained from a remote web service into JSON-LD objects. The ultimate goal of the library is to make it easier the process of consuming JSON APIs from RDF/JSON-LD applications. Similar ideas for transforming JSON documents into RDF have been explored in projects like [jsonGRDDL](http://buzzword.org.uk/2008/jsonGRDDL/spec.20100903).
 
-A demo is available [here](http://ariutta.github.io/json-ld-macros/) .
+A demo is available [here](http://ariutta.github.io/json-ld-macros/tester/) .
 
 ## A Minimal example
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 JSON-LD Macros is a library to define declarative transformations of JSON objects obtained from a remote web service into JSON-LD objects. The ultimate goal of the library is to make it easier the process of consuming JSON APIs from RDF/JSON-LD applications. Similar ideas for transforming JSON documents into RDF have been explored in projects like [jsonGRDDL](http://buzzword.org.uk/2008/jsonGRDDL/spec.20100903).
 
-A demo is available [here](http://antoniogarrote.github.com/json-ld-macros/) .
+A demo is available [here](http://ariutta.github.io/json-ld-macros/) .
 
 ## A Minimal example
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 JSON-LD Macros is a library to define declarative transformations of JSON objects obtained from a remote web service into JSON-LD objects. The ultimate goal of the library is to make it easier the process of consuming JSON APIs from RDF/JSON-LD applications. Similar ideas for transforming JSON documents into RDF have been explored in projects like [jsonGRDDL](http://buzzword.org.uk/2008/jsonGRDDL/spec.20100903).
 
-A demo is available [here](http://ariutta.github.io/json-ld-macros/tester/) .
+A demo is available at [the github.io demo page](http://ariutta.github.io/json-ld-macros/tester/).
 
 ## A Minimal example
 

--- a/tester/index.html
+++ b/tester/index.html
@@ -18,12 +18,12 @@
   <script type='text/javascript' src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
   <script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js'></script>
   <script type='text/javascript' src='http://ajax.microsoft.com/ajax/jquery.templates/beta1/jquery.tmpl.min.js'></script>
- <script type='text/javascript' src='https://raw.github.com/antoniogarrote/rdfstore-js/master/dist/browser/rdf_store_min.js'></script>
+  <script type='text/javascript' src='http://ariutta.github.io/rdfstore-js/dist/browser/rdf_store_min.js'></script>
   <script type='text/javascript' src='./js/bootstrap-modal.js'></script>
   <script type='text/javascript' src='./js/bootstrap-tabs.js'></script>
   <script type='text/javascript' src='./js/beautify.js'></script>
   <script type='text/javascript' src='./js/macro.js'></script>
-  <script type='text/javascript' src='https://raw.github.com/antoniogarrote/semantic-ko/semantic/dist/semko.js'></script>
+  <script type='text/javascript' src='http://ariutta.github.io/semantic-ko/dist/semko.min.js'></script>
   <script type='text/javascript' src='./js/codemirror.js'></script>
   <script type='text/javascript' src='./js/bootstrap-tabs.js'></script>
   <script type='text/javascript' src='./js/modes/javascript.js'></script>


### PR DESCRIPTION
Already opened an issue, but here are the changes I made. This pull request would also need to be merged into gh-pages to actually work.

In the demo, some of the JS files are called from raw.github.com, but that source doesn't work anymore. If you look at my fork, you can see a working version. I moved the content from the master branch to the gh-pages branch so that the JS files are called from github.IO, which does work. I did this for json-ld-macros, semantic-ko and rdfstore-js.

-A
